### PR TITLE
More development improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ pkg/
 tmp
 .rspec
 *.DS_Store
-spec/config.yml
+spec/dropbox.yml

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 #!/usr/bin/env rake
 require "bundler/gem_tasks"
 require "paperclip/dropbox/rake"
+import 'lib/paperclip/dropbox/tasks/authorize.rake'
 
 Bundler.setup
 

--- a/spec/config.example.yml
+++ b/spec/config.example.yml
@@ -1,5 +1,0 @@
-app_key: "your app key"
-app_secret: "your app secret"
-access_token: "your access token"
-access_token_secret: "your access token secret"
-user_id: "your user ID"

--- a/spec/dropbox.yml
+++ b/spec/dropbox.yml
@@ -1,5 +1,0 @@
-app_key: <%= CONFIG[:app_key] %>
-app_secret: <%= CONFIG[:app_secret] %>
-access_token: <%= CONFIG[:access_token] %>
-access_token_secret: <%= CONFIG[:access_token_secret] %>
-user_id: <%= CONFIG[:user_id] %>

--- a/spec/dropbox.yml.example
+++ b/spec/dropbox.yml.example
@@ -1,0 +1,5 @@
+app_key: ""
+app_secret: ""
+access_token: ""
+access_token_secret: ""
+user_id: ""

--- a/spec/paperclip/storage/dropbox_spec.rb
+++ b/spec/paperclip/storage/dropbox_spec.rb
@@ -49,22 +49,22 @@ describe Paperclip::Storage::Dropbox, :vcr do
       end
 
       it "accepts a path to file" do
-        set_options(dropbox_credentials: "#{RSPEC_DIR}/dropbox.yml")
+        set_options(dropbox_credentials: CREDENTIALS_FILE)
         expect { User.new.avatar }.to_not raise_error(KeyError)
       end
 
       it "accepts an open file" do
-        set_options(dropbox_credentials: File.open("#{RSPEC_DIR}/dropbox.yml"))
+        set_options(dropbox_credentials: File.open(CREDENTIALS_FILE))
         expect { User.new.avatar }.to_not raise_error(KeyError)
       end
 
       it "accepts a hash" do
-        set_options(dropbox_credentials: YAML.load(ERB.new(File.read("#{RSPEC_DIR}/dropbox.yml")).result))
+        set_options(dropbox_credentials: CREDENTIALS)
         expect { User.new.avatar }.to_not raise_error(KeyError)
       end
 
       it "recognizes environments" do
-        hash = YAML.load(ERB.new(File.read("#{RSPEC_DIR}/dropbox.yml")).result)
+        hash = YAML.load(ERB.new(File.read(CREDENTIALS_FILE)).result)
 
         set_options(dropbox_credentials: {development: hash}, dropbox_options: {environment: "development"})
         expect { User.new.avatar }.to_not raise_error(KeyError)
@@ -79,7 +79,7 @@ describe Paperclip::Storage::Dropbox, :vcr do
         stub_const("User", Class.new(ActiveRecord::Base) do
           has_attached_file :avatar,
             storage: :dropbox,
-            dropbox_credentials: "#{RSPEC_DIR}/dropbox.yml",
+            dropbox_credentials: CREDENTIALS_FILE,
             dropbox_options: options,
             styles: {medium: "300x300"}
         end)
@@ -125,7 +125,7 @@ describe Paperclip::Storage::Dropbox, :vcr do
       class User < ActiveRecord::Base
         has_attached_file :avatar,
           storage: :dropbox,
-          dropbox_credentials: "#{RSPEC_DIR}/dropbox.yml"
+          dropbox_credentials: CREDENTIALS_FILE
       end
     end
 
@@ -136,7 +136,7 @@ describe Paperclip::Storage::Dropbox, :vcr do
       "Public/photo_with_spaces.jpg".should_not be_on_dropbox
     end
 
-    after(:all) { Object.send(:remove_const, "User") }
+    after(:all) { Object.send(:remove_const, :User) }
   end
 
   describe "#url" do
@@ -144,7 +144,7 @@ describe Paperclip::Storage::Dropbox, :vcr do
       class User < ActiveRecord::Base
         has_attached_file :avatar,
           storage: :dropbox,
-          dropbox_credentials: "#{RSPEC_DIR}/dropbox.yml",
+          dropbox_credentials: CREDENTIALS_FILE,
           styles: {medium: "300x300"}
       end
     end
@@ -173,7 +173,7 @@ describe Paperclip::Storage::Dropbox, :vcr do
       response.code.to_i.should == 200
     end
 
-    after(:each) { @user.destroy }
+    after(:each) { @user.destroy if not @user.nil? }
 
     after(:all) { Object.send(:remove_const, :User) }
   end
@@ -183,7 +183,7 @@ describe Paperclip::Storage::Dropbox, :vcr do
       class User < ActiveRecord::Base
         has_attached_file :avatar,
           storage: :dropbox,
-          dropbox_credentials: "#{RSPEC_DIR}/dropbox.yml"
+          dropbox_credentials: CREDENTIALS_FILE
       end
     end
 
@@ -198,7 +198,7 @@ describe Paperclip::Storage::Dropbox, :vcr do
         expect { User.create(avatar: uploaded_file("photo.jpg", "image/jpeg")) }.to raise_error(Paperclip::Storage::Dropbox::FileExists)
       end
 
-      after(:each) { @user.destroy }
+      after(:each) { @user.destroy if not @user.nil? }
     end
 
     describe "update" do
@@ -216,7 +216,7 @@ describe Paperclip::Storage::Dropbox, :vcr do
         "Public/another_photo.jpg".should be_on_dropbox
       end
 
-      after(:each) { @user.destroy }
+      after(:each) { @user.destroy if not @user.nil? }
     end
 
     describe "destroy" do
@@ -232,7 +232,7 @@ describe Paperclip::Storage::Dropbox, :vcr do
         expect { @user.destroy }.to_not raise_error
       end
 
-      after(:each) { @user.destroy }
+      after(:each) { @user.destroy if not @user.nil? }
     end
 
     after(:all) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,16 @@ require 'active_support/core_ext/hash/keys'
 RSPEC_DIR = File.expand_path(File.dirname(__FILE__))
 Dir[File.join(RSPEC_DIR, "support/**/*.rb")].each { |f| require f }
 
-CONFIG = YAML.load(File.read("#{RSPEC_DIR}/config.yml")).symbolize_keys
+CREDENTIALS_FILE = "#{RSPEC_DIR}/dropbox.yml"
+
+if File.exists?(CREDENTIALS_FILE)
+  CREDENTIALS = YAML.load(ERB.new(File.read(CREDENTIALS_FILE)).result).symbolize_keys
+else
+  puts "\n### ERROR ###"
+  puts "Credential file not found at #{CREDENTIALS_FILE}"
+  puts "Copy dropbox.yml.example and fill in your app credentials.\n\n"
+  raise 'credential file not found'
+end
 
 RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
@@ -15,9 +24,13 @@ end
 VCR.configure do |config|
   config.cassette_library_dir = 'spec/vcr_cassettes'
   config.hook_into :fakeweb
-  config.default_cassette_options = {serialize_with: :syck}
-  config.filter_sensitive_data('API_KEY')      { CONFIG[:app_key] }
-  config.filter_sensitive_data('ACCESS_TOKEN') { CONFIG[:app_secret] }
+  CREDENTIALS.keys.each do |key|
+    config.filter_sensitive_data("<#{key.to_s.upcase}>") { CREDENTIALS[key] }
+  end
+  config.default_cassette_options = {
+    serialize_with: :syck,
+    record: :new_episodes
+  }
   config.configure_rspec_metadata!
   config.allow_http_connections_when_no_cassette = true
 end

--- a/spec/vcr_cassettes/Paperclip_Storage_Dropbox/CUD/create/puts_the_file_on_Dropbox.yml
+++ b/spec/vcr_cassettes/Paperclip_Storage_Dropbox/CUD/create/puts_the_file_on_Dropbox.yml
@@ -12,7 +12,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -21,7 +21,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:02 GMT
+      - Tue, 06 Nov 2012 21:08:39 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -34,7 +34,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:02 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:39 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/photo.jpg?overwrite=false
@@ -1421,7 +1421,7 @@ http_interactions:
       content-length: 
       - 61570
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1430,7 +1430,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:07 GMT
+      - Tue, 06 Nov 2012 21:08:40 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1447,9 +1447,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 686, \"rev\": \"2ae01908bdc\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Sun, 21 Oct 2012 17:21:07 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:21:07 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
+      string: "{\"revision\": 463, \"rev\": \"1cf0b59ac45\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Tue, 06 Nov 2012 21:08:39 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:08:39 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:07 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:40 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo.jpg
@@ -1462,7 +1462,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1471,7 +1471,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:09 GMT
+      - Tue, 06 Nov 2012 21:08:42 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1490,9 +1490,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/m1b9xnv6wv6g00f/Public/photo.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:21:09 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/dktyq4xy4czb71s/Public/photo.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:08:42 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:09 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:42 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo.jpg
@@ -1505,7 +1505,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1514,7 +1514,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:10 GMT
+      - Tue, 06 Nov 2012 21:08:42 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1533,9 +1533,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/m1b9xnv6wv6g00f/Public/photo.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:21:10 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/dktyq4xy4czb71s/Public/photo.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:08:42 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:10 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:42 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fphoto.jpg
@@ -1548,7 +1548,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1557,7 +1557,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:12 GMT
+      - Tue, 06 Nov 2012 21:08:43 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1567,7 +1567,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=MTQ3OTgyNjE0ODMzNzAwNTY1Nzk4Nzk2NTQyMDQ4ODQxMjQxMDc0; expires=Fri, 20-Oct-2017 17:21:12 GMT; Path=/; httponly
+      - gvc=MjQyMDEwNTk5MjY4ODc3Njg1MjQ5OTgwOTc2OTIyODM2OTMwMzYy; expires=Sun, 05-Nov-2017 21:08:43 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -1578,7 +1578,7 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 687, \"rev\": \"2af01908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:21:12 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 464, \"rev\": \"1d00b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:08:43 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:12 GMT
-recorded_with: VCR 2.2.5
+  recorded_at: Tue, 06 Nov 2012 21:08:43 GMT
+recorded_with: VCR 2.3.0

--- a/spec/vcr_cassettes/Paperclip_Storage_Dropbox/CUD/create/raises_an_exception_on_same_filenames.yml
+++ b/spec/vcr_cassettes/Paperclip_Storage_Dropbox/CUD/create/raises_an_exception_on_same_filenames.yml
@@ -12,7 +12,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -21,7 +21,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:13 GMT
+      - Tue, 06 Nov 2012 21:08:44 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -34,7 +34,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:13 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:44 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/photo.jpg?overwrite=false
@@ -1421,7 +1421,7 @@ http_interactions:
       content-length: 
       - 61570
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1430,7 +1430,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:15 GMT
+      - Tue, 06 Nov 2012 21:08:45 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1447,9 +1447,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 688, \"rev\": \"2b001908bdc\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Sun, 21 Oct 2012 17:21:15 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:21:15 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
+      string: "{\"revision\": 465, \"rev\": \"1d10b59ac45\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Tue, 06 Nov 2012 21:08:45 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:08:45 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:15 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:45 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo.jpg
@@ -1462,7 +1462,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1471,7 +1471,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:17 GMT
+      - Tue, 06 Nov 2012 21:08:46 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1490,9 +1490,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/m1b9xnv6wv6g00f/Public/photo.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:21:17 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/dktyq4xy4czb71s/Public/photo.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:08:46 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:17 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:46 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo.jpg
@@ -1505,7 +1505,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1514,7 +1514,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:18 GMT
+      - Tue, 06 Nov 2012 21:08:47 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1533,9 +1533,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/m1b9xnv6wv6g00f/Public/photo.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:21:18 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/dktyq4xy4czb71s/Public/photo.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:08:47 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:18 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:47 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fphoto.jpg
@@ -1548,7 +1548,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1557,7 +1557,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:20 GMT
+      - Tue, 06 Nov 2012 21:08:48 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1567,7 +1567,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=Mjk5Mzg4ODIzMDExNTMyODU1OTU1Mjg2NDMzMDY1MDQ0NjEyODgx; expires=Fri, 20-Oct-2017 17:21:20 GMT; Path=/; httponly
+      - gvc=MTIyNzEzNjQ0MjkzMzIwNDkzNjUyMTg5NTkwMTA1NzM2OTM4OTAy; expires=Sun, 05-Nov-2017 21:08:48 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -1578,7 +1578,7 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 689, \"rev\": \"2b101908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:21:20 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 466, \"rev\": \"1d20b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:08:47 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:20 GMT
-recorded_with: VCR 2.2.5
+  recorded_at: Tue, 06 Nov 2012 21:08:48 GMT
+recorded_with: VCR 2.3.0

--- a/spec/vcr_cassettes/Paperclip_Storage_Dropbox/CUD/destroy/deletes_the_uploaded_file.yml
+++ b/spec/vcr_cassettes/Paperclip_Storage_Dropbox/CUD/destroy/deletes_the_uploaded_file.yml
@@ -12,7 +12,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -21,7 +21,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:22:06 GMT
+      - Tue, 06 Nov 2012 21:09:04 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -34,7 +34,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:22:06 GMT
+  recorded_at: Tue, 06 Nov 2012 21:09:04 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/photo.jpg?overwrite=false
@@ -1421,7 +1421,7 @@ http_interactions:
       content-length: 
       - 61570
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1430,7 +1430,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:22:08 GMT
+      - Tue, 06 Nov 2012 21:09:05 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1447,9 +1447,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 698, \"rev\": \"2ba01908bdc\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Sun, 21 Oct 2012 17:22:08 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:22:08 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
+      string: "{\"revision\": 475, \"rev\": \"1db0b59ac45\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Tue, 06 Nov 2012 21:09:05 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:09:05 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:22:08 GMT
+  recorded_at: Tue, 06 Nov 2012 21:09:05 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo.jpg
@@ -1462,7 +1462,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1471,7 +1471,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:22:09 GMT
+      - Tue, 06 Nov 2012 21:09:06 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1490,9 +1490,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/m1b9xnv6wv6g00f/Public/photo.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:22:09 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/dktyq4xy4czb71s/Public/photo.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:09:06 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:22:09 GMT
+  recorded_at: Tue, 06 Nov 2012 21:09:06 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fphoto.jpg
@@ -1505,7 +1505,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1514,7 +1514,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:22:11 GMT
+      - Tue, 06 Nov 2012 21:09:07 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1524,7 +1524,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=NzIwMjMwMDIwMTk5OTY5NTA1NjIzMjI0MzE0NzE4NTczNDE5MjM%3D; expires=Fri, 20-Oct-2017 17:22:11 GMT; Path=/; httponly
+      - gvc=Njg1NzkxNjA4NjM2ODA3NTgyOTU3MTMxNjY1MDA4MjM1NjQ0NTA%3D; expires=Sun, 05-Nov-2017 21:09:07 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -1535,9 +1535,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 699, \"rev\": \"2bb01908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:22:11 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 476, \"rev\": \"1dc0b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:09:07 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:22:11 GMT
+  recorded_at: Tue, 06 Nov 2012 21:09:07 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo.jpg
@@ -1550,7 +1550,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -1559,7 +1559,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:22:12 GMT
+      - Tue, 06 Nov 2012 21:09:08 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -1572,5 +1572,5 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:22:13 GMT
-recorded_with: VCR 2.2.5
+  recorded_at: Tue, 06 Nov 2012 21:09:08 GMT
+recorded_with: VCR 2.3.0

--- a/spec/vcr_cassettes/Paperclip_Storage_Dropbox/CUD/destroy/doesn_t_raise_errors_if_there_are_no_files_to_delete.yml
+++ b/spec/vcr_cassettes/Paperclip_Storage_Dropbox/CUD/destroy/doesn_t_raise_errors_if_there_are_no_files_to_delete.yml
@@ -12,7 +12,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -21,7 +21,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:22:14 GMT
+      - Tue, 06 Nov 2012 21:09:09 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -34,7 +34,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:22:14 GMT
+  recorded_at: Tue, 06 Nov 2012 21:09:09 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/photo.jpg?overwrite=false
@@ -1421,7 +1421,7 @@ http_interactions:
       content-length: 
       - 61570
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1430,7 +1430,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:22:16 GMT
+      - Tue, 06 Nov 2012 21:09:10 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1447,9 +1447,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 700, \"rev\": \"2bc01908bdc\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Sun, 21 Oct 2012 17:22:16 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:22:16 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
+      string: "{\"revision\": 477, \"rev\": \"1dd0b59ac45\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Tue, 06 Nov 2012 21:09:09 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:09:09 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:22:16 GMT
+  recorded_at: Tue, 06 Nov 2012 21:09:10 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fphoto.jpg
@@ -1462,7 +1462,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1471,7 +1471,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:22:18 GMT
+      - Tue, 06 Nov 2012 21:09:10 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1481,7 +1481,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=MjU1Nzc4Mjg1NTQzOTI3OTgxNjc5ODQyMDQ2ODcxNTkzMzgwMjgz; expires=Fri, 20-Oct-2017 17:22:18 GMT; Path=/; httponly
+      - gvc=OTU1NzMwNDE3NzA1MzAzNzc4NzQ5NDQwMzE3Mzk3MTk3MjQ2OTA%3D; expires=Sun, 05-Nov-2017 21:09:10 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -1492,9 +1492,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 701, \"rev\": \"2bd01908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:22:18 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 478, \"rev\": \"1de0b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:09:10 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:22:18 GMT
+  recorded_at: Tue, 06 Nov 2012 21:09:11 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo.jpg
@@ -1507,7 +1507,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -1516,7 +1516,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:22:19 GMT
+      - Tue, 06 Nov 2012 21:09:11 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -1529,5 +1529,5 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:22:19 GMT
-recorded_with: VCR 2.2.5
+  recorded_at: Tue, 06 Nov 2012 21:09:11 GMT
+recorded_with: VCR 2.3.0

--- a/spec/vcr_cassettes/Paperclip_Storage_Dropbox/CUD/update/deletes_the_old_file_and_uploads_the_new_one.yml
+++ b/spec/vcr_cassettes/Paperclip_Storage_Dropbox/CUD/update/deletes_the_old_file_and_uploads_the_new_one.yml
@@ -12,7 +12,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -21,7 +21,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:30 GMT
+      - Tue, 06 Nov 2012 21:08:52 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -34,7 +34,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:31 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:52 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/photo.jpg?overwrite=false
@@ -1421,7 +1421,7 @@ http_interactions:
       content-length: 
       - 61570
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1430,7 +1430,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:32 GMT
+      - Tue, 06 Nov 2012 21:08:53 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1447,9 +1447,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 692, \"rev\": \"2b401908bdc\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Sun, 21 Oct 2012 17:21:32 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:21:32 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
+      string: "{\"revision\": 469, \"rev\": \"1d50b59ac45\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Tue, 06 Nov 2012 21:08:53 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:08:53 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:33 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:53 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo.jpg
@@ -1462,7 +1462,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1471,7 +1471,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:34 GMT
+      - Tue, 06 Nov 2012 21:08:54 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1490,9 +1490,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/m1b9xnv6wv6g00f/Public/photo.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:21:34 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/dktyq4xy4czb71s/Public/photo.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:08:54 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:34 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:54 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fphoto.jpg
@@ -1505,7 +1505,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1514,7 +1514,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:35 GMT
+      - Tue, 06 Nov 2012 21:08:55 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1524,7 +1524,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=MTAxMjE5NjE4OTQ0NDU0NTE5MjcxNDE0NDI4MzMzMzYwOTYzMDEx; expires=Fri, 20-Oct-2017 17:21:35 GMT; Path=/; httponly
+      - gvc=MTQ3NzkwNTQ3NjQzNjc0MjQzNzUyMTI4NzUwMDY0MTY2OTU5MTQw; expires=Sun, 05-Nov-2017 21:08:55 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -1535,9 +1535,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 693, \"rev\": \"2b501908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:21:35 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 470, \"rev\": \"1d60b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:08:54 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:36 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:55 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo.jpg
@@ -1550,7 +1550,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -1559,7 +1559,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:37 GMT
+      - Tue, 06 Nov 2012 21:08:55 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -1572,7 +1572,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:37 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:55 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/photo.jpg?overwrite=false
@@ -2959,7 +2959,7 @@ http_interactions:
       content-length: 
       - 61570
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2968,7 +2968,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:39 GMT
+      - Tue, 06 Nov 2012 21:08:56 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2985,9 +2985,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 694, \"rev\": \"2b601908bdc\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Sun, 21 Oct 2012 17:21:39 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:21:39 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
+      string: "{\"revision\": 471, \"rev\": \"1d70b59ac45\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Tue, 06 Nov 2012 21:08:56 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:08:56 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:39 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:56 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo.jpg
@@ -3000,7 +3000,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -3009,7 +3009,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:40 GMT
+      - Tue, 06 Nov 2012 21:08:57 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -3028,9 +3028,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/m1b9xnv6wv6g00f/Public/photo.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:21:40 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/dktyq4xy4czb71s/Public/photo.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:08:57 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:41 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:57 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fphoto.jpg
@@ -3043,7 +3043,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -3052,7 +3052,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:42 GMT
+      - Tue, 06 Nov 2012 21:08:58 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -3062,7 +3062,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=MzUyNDIzNzc1MTI1MDU3NTEwNDE5MzUxMTUwNDEzMDU2MTUyOTU%3D; expires=Fri, 20-Oct-2017 17:21:42 GMT; Path=/; httponly
+      - gvc=MjU2NDAwMTQxMTM5ODg0ODEzNTEzMzgwOTcyNjI5NTI5NDY4MjY3; expires=Sun, 05-Nov-2017 21:08:57 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -3073,9 +3073,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 695, \"rev\": \"2b701908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:21:42 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 472, \"rev\": \"1d80b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:08:57 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:42 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:58 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/another_photo.jpg
@@ -3088,7 +3088,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -3097,7 +3097,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:56 GMT
+      - Tue, 06 Nov 2012 21:08:58 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -3110,7 +3110,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/another_photo.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:56 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:58 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/another_photo.jpg?overwrite=false
@@ -4497,7 +4497,7 @@ http_interactions:
       content-length: 
       - 61570
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -4506,7 +4506,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:58 GMT
+      - Tue, 06 Nov 2012 21:09:00 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -4523,9 +4523,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 696, \"rev\": \"2b801908bdc\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Sun, 21 Oct 2012 17:21:58 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:21:58 +0000\", \"path\": \"/Public/another_photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
+      string: "{\"revision\": 473, \"rev\": \"1d90b59ac45\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Tue, 06 Nov 2012 21:08:59 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:08:59 +0000\", \"path\": \"/Public/another_photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:58 GMT
+  recorded_at: Tue, 06 Nov 2012 21:09:00 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo.jpg
@@ -4538,7 +4538,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -4547,7 +4547,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:22:00 GMT
+      - Tue, 06 Nov 2012 21:09:00 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -4560,7 +4560,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:22:00 GMT
+  recorded_at: Tue, 06 Nov 2012 21:09:00 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/another_photo.jpg
@@ -4573,7 +4573,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -4582,7 +4582,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:22:01 GMT
+      - Tue, 06 Nov 2012 21:09:01 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -4601,9 +4601,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/eht8n6qk2powysu/Public/another_photo.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:22:01 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/u4jha2jzffzc7g8/Public/another_photo.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:09:01 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:22:01 GMT
+  recorded_at: Tue, 06 Nov 2012 21:09:01 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/another_photo.jpg
@@ -4616,7 +4616,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -4625,7 +4625,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:22:03 GMT
+      - Tue, 06 Nov 2012 21:09:03 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -4644,9 +4644,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/eht8n6qk2powysu/Public/another_photo.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:22:03 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/u4jha2jzffzc7g8/Public/another_photo.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:09:03 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:22:03 GMT
+  recorded_at: Tue, 06 Nov 2012 21:09:03 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fanother_photo.jpg
@@ -4659,7 +4659,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -4668,7 +4668,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:22:04 GMT
+      - Tue, 06 Nov 2012 21:09:04 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -4678,7 +4678,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=MTQ1NDE0NDc1ODM4NDA5OTI0NjQxNDI2NzM3NDI2MzAyODQ1NDc3; expires=Fri, 20-Oct-2017 17:22:04 GMT; Path=/; httponly
+      - gvc=MzY5NDIzNDkzMTE0MjU2NjMxODczNzA5MzczNDQ0MDU0NDcyMTE%3D; expires=Sun, 05-Nov-2017 21:09:04 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -4689,7 +4689,7 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 697, \"rev\": \"2b901908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:22:04 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/another_photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 474, \"rev\": \"1da0b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:09:03 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/another_photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:22:04 GMT
-recorded_with: VCR 2.2.5
+  recorded_at: Tue, 06 Nov 2012 21:09:04 GMT
+recorded_with: VCR 2.3.0

--- a/spec/vcr_cassettes/Paperclip_Storage_Dropbox/CUD/update/deletes_the_old_file_if_set_to_nil.yml
+++ b/spec/vcr_cassettes/Paperclip_Storage_Dropbox/CUD/update/deletes_the_old_file_if_set_to_nil.yml
@@ -12,7 +12,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -21,7 +21,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:21 GMT
+      - Tue, 06 Nov 2012 21:08:48 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -34,7 +34,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:21 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:48 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/photo.jpg?overwrite=false
@@ -1421,7 +1421,7 @@ http_interactions:
       content-length: 
       - 61570
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1430,7 +1430,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:24 GMT
+      - Tue, 06 Nov 2012 21:08:49 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1447,9 +1447,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 690, \"rev\": \"2b201908bdc\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Sun, 21 Oct 2012 17:21:24 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:21:24 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
+      string: "{\"revision\": 467, \"rev\": \"1d30b59ac45\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Tue, 06 Nov 2012 21:08:49 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:08:49 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:25 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:49 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo.jpg
@@ -1462,7 +1462,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1471,7 +1471,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:26 GMT
+      - Tue, 06 Nov 2012 21:08:50 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1490,9 +1490,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/m1b9xnv6wv6g00f/Public/photo.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:21:26 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/dktyq4xy4czb71s/Public/photo.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:08:50 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:26 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:50 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fphoto.jpg
@@ -1505,7 +1505,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1514,7 +1514,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:27 GMT
+      - Tue, 06 Nov 2012 21:08:51 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1524,7 +1524,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=NjQzOTc0MTMyNzc1MTY3Nzc1MDM3NzM1NTk0OTE5MTIzOTE3MTY%3D; expires=Fri, 20-Oct-2017 17:21:27 GMT; Path=/; httponly
+      - gvc=MjEyNjkwNTk5Nzc1NDU3ODc2MTE4NDY1Mzk1NTEzNzkxOTI1MDE1; expires=Sun, 05-Nov-2017 21:08:51 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -1535,9 +1535,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 691, \"rev\": \"2b301908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:21:27 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 468, \"rev\": \"1d40b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:08:50 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:28 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:51 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo.jpg
@@ -1550,7 +1550,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -1559,7 +1559,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:21:29 GMT
+      - Tue, 06 Nov 2012 21:08:51 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -1572,5 +1572,5 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:21:29 GMT
-recorded_with: VCR 2.2.5
+  recorded_at: Tue, 06 Nov 2012 21:08:51 GMT
+recorded_with: VCR 2.3.0

--- a/spec/vcr_cassettes/Paperclip_Storage_Dropbox/_url/accepts_the_download_option.yml
+++ b/spec/vcr_cassettes/Paperclip_Storage_Dropbox/_url/accepts_the_download_option.yml
@@ -12,7 +12,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -21,7 +21,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:40 GMT
+      - Tue, 06 Nov 2012 21:08:31 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -34,7 +34,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:40 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:31 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/photo.jpg?overwrite=false
@@ -1421,7 +1421,7 @@ http_interactions:
       content-length: 
       - 61570
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1430,7 +1430,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:42 GMT
+      - Tue, 06 Nov 2012 21:08:32 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1447,9 +1447,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 682, \"rev\": \"2aa01908bdc\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Sun, 21 Oct 2012 17:19:42 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:19:42 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
+      string: "{\"revision\": 459, \"rev\": \"1cb0b59ac45\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Tue, 06 Nov 2012 21:08:32 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:08:32 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:42 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:32 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo_medium.jpg
@@ -1462,7 +1462,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -1471,7 +1471,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:44 GMT
+      - Tue, 06 Nov 2012 21:08:33 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -1484,7 +1484,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo_medium.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:44 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:33 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/photo_medium.jpg?overwrite=false
@@ -2106,7 +2106,7 @@ http_interactions:
       content-length: 
       - 27143
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2115,7 +2115,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:46 GMT
+      - Tue, 06 Nov 2012 21:08:34 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2132,12 +2132,12 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 683, \"rev\": \"2ab01908bdc\", \"thumb_exists\": true, \"bytes\": 27143, \"modified\": \"Sun, 21 Oct 2012 17:19:45 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:19:45 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"26.5 KB\"}"
+      string: "{\"revision\": 460, \"rev\": \"1cc0b59ac45\", \"thumb_exists\": true, \"bytes\": 27143, \"modified\": \"Tue, 06 Nov 2012 21:08:33 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:08:33 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"26.5 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:46 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:34 GMT
 - request: 
     method: get
-    uri: http://dl.dropbox.com/u/16783504/photo.jpg?dl=1
+    uri: http://dl.dropbox.com/u/<USER_ID>/photo.jpg?dl=1
     body: 
       encoding: US-ASCII
       string: ""
@@ -2154,7 +2154,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:46 GMT
+      - Tue, 06 Nov 2012 21:08:34 GMT
       content-type: 
       - image/jpeg
       content-length: 
@@ -2166,9 +2166,9 @@ http_interactions:
       content-disposition: 
       - attachment; filename="photo.jpg"
       accept-ranges: 
-      - bytes
+      - none
       etag: 
-      - 682d
+      - 459d
       pragma: 
       - public
       cache-control: 
@@ -3547,10 +3547,10 @@ http_interactions:
         nbjHpRRRQB//2Q==
 
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:47 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:34 GMT
 - request: 
     method: get
-    uri: http://dl.dropbox.com/u/16783504/photo_medium.jpg?dl=1
+    uri: http://dl.dropbox.com/u/<USER_ID>/photo_medium.jpg?dl=1
     body: 
       encoding: US-ASCII
       string: ""
@@ -3567,7 +3567,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:47 GMT
+      - Tue, 06 Nov 2012 21:08:35 GMT
       content-type: 
       - image/jpeg
       content-length: 
@@ -3579,9 +3579,9 @@ http_interactions:
       content-disposition: 
       - attachment; filename="photo_medium.jpg"
       accept-ranges: 
-      - bytes
+      - none
       etag: 
-      - 683d
+      - 460d
       pragma: 
       - public
       cache-control: 
@@ -4195,7 +4195,7 @@ http_interactions:
         1ms18vl//9k=
 
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:48 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:35 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo.jpg
@@ -4208,7 +4208,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -4217,7 +4217,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:49 GMT
+      - Tue, 06 Nov 2012 21:08:35 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -4236,9 +4236,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/m1b9xnv6wv6g00f/Public/photo.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:19:49 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/dktyq4xy4czb71s/Public/photo.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:08:35 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:49 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:35 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo_medium.jpg
@@ -4251,7 +4251,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -4260,7 +4260,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:51 GMT
+      - Tue, 06 Nov 2012 21:08:36 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -4279,9 +4279,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/1oq5rwmdvli38s1/Public/photo_medium.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:19:51 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/bfv25j41ykm166h/Public/photo_medium.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:08:36 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:51 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:36 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fphoto.jpg
@@ -4294,7 +4294,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -4303,7 +4303,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:54 GMT
+      - Tue, 06 Nov 2012 21:08:37 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -4313,7 +4313,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=MjE0MTIyNTA2ODA1OTU3OTA2MzcyNjcxODIzMTMyMTU1NTg1NTE%3D; expires=Fri, 20-Oct-2017 17:19:54 GMT; Path=/; httponly
+      - gvc=Mjc1NTA5ODU4MTkyODM3NDAxNzg3MDM3NjQ3NzIxODEwMzQ3Mjk3; expires=Sun, 05-Nov-2017 21:08:37 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -4324,9 +4324,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 684, \"rev\": \"2ac01908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:19:53 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 461, \"rev\": \"1cd0b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:08:37 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:54 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:37 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fphoto_medium.jpg
@@ -4339,7 +4339,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -4348,7 +4348,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:55 GMT
+      - Tue, 06 Nov 2012 21:08:38 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -4358,7 +4358,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=MjE5MDEyMDcwMjE1OTk2NjYzNTY1MzQ3MjQ0MTEyNzIwOTczMjA5; expires=Fri, 20-Oct-2017 17:19:55 GMT; Path=/; httponly
+      - gvc=MjYwNjY4NDIyNzI2MDQ3ODU4NjI4NjQ0NDQ4MDE3Njk3NDE0NDI1; expires=Sun, 05-Nov-2017 21:08:38 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -4369,7 +4369,7 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 685, \"rev\": \"2ad01908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:19:55 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 462, \"rev\": \"1ce0b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:08:38 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:55 GMT
-recorded_with: VCR 2.2.5
+  recorded_at: Tue, 06 Nov 2012 21:08:38 GMT
+recorded_with: VCR 2.3.0

--- a/spec/vcr_cassettes/Paperclip_Storage_Dropbox/_url/defaults_to_original_size.yml
+++ b/spec/vcr_cassettes/Paperclip_Storage_Dropbox/_url/defaults_to_original_size.yml
@@ -12,7 +12,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -21,7 +21,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:27 GMT
+      - Tue, 06 Nov 2012 21:08:21 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -34,7 +34,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:27 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:21 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/photo.jpg?overwrite=false
@@ -1421,7 +1421,7 @@ http_interactions:
       content-length: 
       - 61570
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1430,7 +1430,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:29 GMT
+      - Tue, 06 Nov 2012 21:08:22 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1447,9 +1447,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 678, \"rev\": \"2a601908bdc\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Sun, 21 Oct 2012 17:19:29 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:19:29 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
+      string: "{\"revision\": 455, \"rev\": \"1c70b59ac45\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Tue, 06 Nov 2012 21:08:22 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:08:22 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:29 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:22 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo_medium.jpg
@@ -1462,7 +1462,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -1471,7 +1471,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:30 GMT
+      - Tue, 06 Nov 2012 21:08:23 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -1484,7 +1484,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo_medium.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:31 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:23 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/photo_medium.jpg?overwrite=false
@@ -2106,7 +2106,7 @@ http_interactions:
       content-length: 
       - 27143
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2115,7 +2115,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:32 GMT
+      - Tue, 06 Nov 2012 21:08:24 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2132,9 +2132,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 679, \"rev\": \"2a701908bdc\", \"thumb_exists\": true, \"bytes\": 27143, \"modified\": \"Sun, 21 Oct 2012 17:19:32 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:19:32 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"26.5 KB\"}"
+      string: "{\"revision\": 456, \"rev\": \"1c80b59ac45\", \"thumb_exists\": true, \"bytes\": 27143, \"modified\": \"Tue, 06 Nov 2012 21:08:24 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:08:24 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"26.5 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:32 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:24 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo.jpg
@@ -2147,7 +2147,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2156,7 +2156,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:34 GMT
+      - Tue, 06 Nov 2012 21:08:25 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2175,9 +2175,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/m1b9xnv6wv6g00f/Public/photo.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:19:34 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/dktyq4xy4czb71s/Public/photo.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:08:25 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:34 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:25 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo_medium.jpg
@@ -2190,7 +2190,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2199,7 +2199,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:35 GMT
+      - Tue, 06 Nov 2012 21:08:26 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2218,9 +2218,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/1oq5rwmdvli38s1/Public/photo_medium.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:19:35 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/bfv25j41ykm166h/Public/photo_medium.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:08:26 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:35 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:26 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fphoto.jpg
@@ -2233,7 +2233,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2242,7 +2242,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:37 GMT
+      - Tue, 06 Nov 2012 21:08:27 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2252,7 +2252,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=MTUzNDQxNjA0ODMzMDk4OTY3MTk4MDM2MzQyNTI3MDY4MTMwOTQz; expires=Fri, 20-Oct-2017 17:19:37 GMT; Path=/; httponly
+      - gvc=NTI5MzUzNzAyMzYxNzMyMDk0MDE2ODI1MTU0NjI1OTA5NjEzNzQ%3D; expires=Sun, 05-Nov-2017 21:08:27 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -2263,9 +2263,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 680, \"rev\": \"2a801908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:19:36 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 457, \"rev\": \"1c90b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:08:26 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:37 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:27 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fphoto_medium.jpg
@@ -2278,7 +2278,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2287,7 +2287,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:38 GMT
+      - Tue, 06 Nov 2012 21:08:28 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2297,7 +2297,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=MTIyODE5MzIyMzE1NTYxMjczMzI4MTM5MTkwODI1NjA1NjE4ODY3; expires=Fri, 20-Oct-2017 17:19:38 GMT; Path=/; httponly
+      - gvc=MTQ3MzU5ODY0NzMxMjMxNjU0NjAwMzYwNTQ4NDA5NjAzODM0MTA4; expires=Sun, 05-Nov-2017 21:08:28 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -2308,7 +2308,7 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 681, \"rev\": \"2a901908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:19:38 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 458, \"rev\": \"1ca0b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:08:28 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:38 GMT
-recorded_with: VCR 2.2.5
+  recorded_at: Tue, 06 Nov 2012 21:08:30 GMT
+recorded_with: VCR 2.3.0

--- a/spec/vcr_cassettes/Paperclip_Storage_Dropbox/_url/is_valid.yml
+++ b/spec/vcr_cassettes/Paperclip_Storage_Dropbox/_url/is_valid.yml
@@ -12,7 +12,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -21,7 +21,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:11 GMT
+      - Tue, 06 Nov 2012 21:08:12 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -34,7 +34,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:11 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:12 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/photo.jpg?overwrite=false
@@ -1421,7 +1421,7 @@ http_interactions:
       content-length: 
       - 61570
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1430,7 +1430,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:14 GMT
+      - Tue, 06 Nov 2012 21:08:13 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1447,9 +1447,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 674, \"rev\": \"2a201908bdc\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Sun, 21 Oct 2012 17:19:14 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:19:14 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
+      string: "{\"revision\": 451, \"rev\": \"1c30b59ac45\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Tue, 06 Nov 2012 21:08:13 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:08:13 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:14 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:13 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo_medium.jpg
@@ -1462,7 +1462,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -1471,7 +1471,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:15 GMT
+      - Tue, 06 Nov 2012 21:08:14 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -1484,7 +1484,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo_medium.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:15 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:14 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/photo_medium.jpg?overwrite=false
@@ -2106,7 +2106,7 @@ http_interactions:
       content-length: 
       - 27143
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2115,7 +2115,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:17 GMT
+      - Tue, 06 Nov 2012 21:08:15 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2132,12 +2132,12 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 675, \"rev\": \"2a301908bdc\", \"thumb_exists\": true, \"bytes\": 27143, \"modified\": \"Sun, 21 Oct 2012 17:19:17 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:19:17 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"26.5 KB\"}"
+      string: "{\"revision\": 452, \"rev\": \"1c40b59ac45\", \"thumb_exists\": true, \"bytes\": 27143, \"modified\": \"Tue, 06 Nov 2012 21:08:14 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:08:14 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"26.5 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:17 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:15 GMT
 - request: 
     method: get
-    uri: http://dl.dropbox.com/u/16783504/photo.jpg
+    uri: http://dl.dropbox.com/u/<USER_ID>/photo.jpg
     body: 
       encoding: US-ASCII
       string: ""
@@ -2154,7 +2154,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:10 GMT
+      - Tue, 06 Nov 2012 21:08:15 GMT
       content-type: 
       - image/jpeg
       content-length: 
@@ -2164,9 +2164,9 @@ http_interactions:
       x-robots-tag: 
       - noindex,nofollow
       accept-ranges: 
-      - bytes
+      - none
       etag: 
-      - 674n
+      - 451n
       pragma: 
       - public
       cache-control: 
@@ -3545,10 +3545,10 @@ http_interactions:
         nbjHpRRRQB//2Q==
 
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:18 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:16 GMT
 - request: 
     method: get
-    uri: http://dl.dropbox.com/u/16783504/photo_medium.jpg
+    uri: http://dl.dropbox.com/u/<USER_ID>/photo_medium.jpg
     body: 
       encoding: US-ASCII
       string: ""
@@ -3565,7 +3565,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:18 GMT
+      - Tue, 06 Nov 2012 21:08:16 GMT
       content-type: 
       - image/jpeg
       content-length: 
@@ -3575,9 +3575,9 @@ http_interactions:
       x-robots-tag: 
       - noindex,nofollow
       accept-ranges: 
-      - bytes
+      - none
       etag: 
-      - 675n
+      - 452n
       pragma: 
       - public
       cache-control: 
@@ -4191,7 +4191,7 @@ http_interactions:
         1ms18vl//9k=
 
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:19 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:16 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo.jpg
@@ -4204,7 +4204,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -4213,7 +4213,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:20 GMT
+      - Tue, 06 Nov 2012 21:08:17 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -4232,9 +4232,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/m1b9xnv6wv6g00f/Public/photo.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:19:20 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/dktyq4xy4czb71s/Public/photo.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:08:17 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:20 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:17 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo_medium.jpg
@@ -4247,7 +4247,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -4256,7 +4256,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:22 GMT
+      - Tue, 06 Nov 2012 21:08:18 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -4275,9 +4275,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/1oq5rwmdvli38s1/Public/photo_medium.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:19:22 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/bfv25j41ykm166h/Public/photo_medium.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:08:18 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:22 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:18 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fphoto.jpg
@@ -4290,7 +4290,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -4299,7 +4299,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:23 GMT
+      - Tue, 06 Nov 2012 21:08:19 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -4309,7 +4309,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=MjA2MjExMDA5NTUyNDcyMTI0NDIxMTg5ODg1MzMwNDYzNTUxMzky; expires=Fri, 20-Oct-2017 17:19:23 GMT; Path=/; httponly
+      - gvc=MzMzMjQ3NzQzOTU2Nzg4OTA0ODM1MDA1ODgxNTgyMTY3NTQ0Njg2; expires=Sun, 05-Nov-2017 21:08:19 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -4320,9 +4320,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 676, \"rev\": \"2a401908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:19:23 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 453, \"rev\": \"1c50b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:08:18 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:23 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:19 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fphoto_medium.jpg
@@ -4335,7 +4335,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -4344,7 +4344,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:25 GMT
+      - Tue, 06 Nov 2012 21:08:20 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -4354,7 +4354,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=MTc1MTIzMDI0NTgxNjYwMzAzMjQ1Njc1OTMzNTE0OTQ5MjM4MTc1; expires=Fri, 20-Oct-2017 17:19:25 GMT; Path=/; httponly
+      - gvc=NzQ1MTI1NzA1Njk4MTI5MzQ2MjIxMDMxMjc2MzIxNzI2MzI4ODI%3D; expires=Sun, 05-Nov-2017 21:08:20 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -4365,7 +4365,7 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 677, \"rev\": \"2a501908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:19:25 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 454, \"rev\": \"1c60b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:08:20 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:25 GMT
-recorded_with: VCR 2.2.5
+  recorded_at: Tue, 06 Nov 2012 21:08:20 GMT
+recorded_with: VCR 2.3.0

--- a/spec/vcr_cassettes/Paperclip_Storage_Dropbox/_url/returns_nil_when_the_file_doesn_t_exist.yml
+++ b/spec/vcr_cassettes/Paperclip_Storage_Dropbox/_url/returns_nil_when_the_file_doesn_t_exist.yml
@@ -12,7 +12,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -21,7 +21,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:18:58 GMT
+      - Tue, 06 Nov 2012 21:08:05 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -34,7 +34,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:18:58 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:05 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/photo.jpg?overwrite=false
@@ -1421,7 +1421,7 @@ http_interactions:
       content-length: 
       - 61570
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1430,7 +1430,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:00 GMT
+      - Tue, 06 Nov 2012 21:08:06 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1447,9 +1447,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 670, \"rev\": \"29e01908bdc\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Sun, 21 Oct 2012 17:19:00 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:19:00 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
+      string: "{\"revision\": 447, \"rev\": \"1bf0b59ac45\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Tue, 06 Nov 2012 21:08:06 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:08:06 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:00 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:06 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo_medium.jpg
@@ -1462,7 +1462,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -1471,7 +1471,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:02 GMT
+      - Tue, 06 Nov 2012 21:08:07 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -1484,7 +1484,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo_medium.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:02 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:07 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/photo_medium.jpg?overwrite=false
@@ -2106,7 +2106,7 @@ http_interactions:
       content-length: 
       - 27143
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2115,7 +2115,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:04 GMT
+      - Tue, 06 Nov 2012 21:08:07 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2132,9 +2132,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 671, \"rev\": \"29f01908bdc\", \"thumb_exists\": true, \"bytes\": 27143, \"modified\": \"Sun, 21 Oct 2012 17:19:03 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:19:03 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"26.5 KB\"}"
+      string: "{\"revision\": 448, \"rev\": \"1c00b59ac45\", \"thumb_exists\": true, \"bytes\": 27143, \"modified\": \"Tue, 06 Nov 2012 21:08:07 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:08:07 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"26.5 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:04 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:07 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo.jpg
@@ -2147,7 +2147,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2156,7 +2156,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:05 GMT
+      - Tue, 06 Nov 2012 21:08:08 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2175,9 +2175,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/m1b9xnv6wv6g00f/Public/photo.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:19:05 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/dktyq4xy4czb71s/Public/photo.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:08:08 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:05 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:08 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo_medium.jpg
@@ -2190,7 +2190,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2199,7 +2199,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:07 GMT
+      - Tue, 06 Nov 2012 21:08:09 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2218,9 +2218,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/1oq5rwmdvli38s1/Public/photo_medium.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:19:07 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/bfv25j41ykm166h/Public/photo_medium.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:08:09 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:07 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:09 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fphoto.jpg
@@ -2233,7 +2233,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2242,7 +2242,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:08 GMT
+      - Tue, 06 Nov 2012 21:08:10 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2252,7 +2252,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=Mjk2NTIxNDc1NjcyNjQ2NDUzMDIzMzY0MDM4MzE1MDU0MDE5MjYy; expires=Fri, 20-Oct-2017 17:19:08 GMT; Path=/; httponly
+      - gvc=MjE2MzcwODc4OTU3OTA1NjgzMDczMjMzNzA4MTUxMDE0MTk1ODEy; expires=Sun, 05-Nov-2017 21:08:10 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -2263,9 +2263,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 672, \"rev\": \"2a001908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:19:08 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 449, \"rev\": \"1c10b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:08:09 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:08 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:10 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fphoto_medium.jpg
@@ -2278,7 +2278,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2287,7 +2287,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:19:10 GMT
+      - Tue, 06 Nov 2012 21:08:11 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2297,7 +2297,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=MzM5MjI0OTYyMzk5MzkwNDU3MTE0NjcwMzY0Mjg3NTA2NTg0ODYz; expires=Fri, 20-Oct-2017 17:19:10 GMT; Path=/; httponly
+      - gvc=MjQwMDc4ODkwMjkzNDU2NTUzMjA4Mzc2MTEwOTI1NjY0MDI0MTk%3D; expires=Sun, 05-Nov-2017 21:08:11 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -2308,7 +2308,7 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 673, \"rev\": \"2a101908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:19:10 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 450, \"rev\": \"1c20b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:08:11 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:19:10 GMT
-recorded_with: VCR 2.2.5
+  recorded_at: Tue, 06 Nov 2012 21:08:11 GMT
+recorded_with: VCR 2.3.0

--- a/spec/vcr_cassettes/Paperclip_Storage_Dropbox/arguments_for_has_attached_file/dropbox_options/path/doesn_t_duplicate_the_extension.yml
+++ b/spec/vcr_cassettes/Paperclip_Storage_Dropbox/arguments_for_has_attached_file/dropbox_options/path/doesn_t_duplicate_the_extension.yml
@@ -12,7 +12,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -21,7 +21,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:11:52 GMT
+      - Tue, 06 Nov 2012 21:07:33 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -34,7 +34,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:11:52 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:33 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/photo.jpg?overwrite=false
@@ -1421,7 +1421,7 @@ http_interactions:
       content-length: 
       - 61570
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1430,7 +1430,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:11:54 GMT
+      - Tue, 06 Nov 2012 21:07:34 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1447,9 +1447,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 634, \"rev\": \"27a01908bdc\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Sun, 21 Oct 2012 17:11:54 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:11:54 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
+      string: "{\"revision\": 429, \"rev\": \"1ad0b59ac45\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Tue, 06 Nov 2012 21:07:34 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:07:34 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:11:55 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:34 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo_medium.jpg
@@ -1462,7 +1462,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -1471,7 +1471,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:11:56 GMT
+      - Tue, 06 Nov 2012 21:07:35 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -1484,7 +1484,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo_medium.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:11:56 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:35 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/photo_medium.jpg?overwrite=false
@@ -2106,7 +2106,7 @@ http_interactions:
       content-length: 
       - 27143
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2115,7 +2115,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:11:58 GMT
+      - Tue, 06 Nov 2012 21:07:35 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2132,9 +2132,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 635, \"rev\": \"27b01908bdc\", \"thumb_exists\": true, \"bytes\": 27143, \"modified\": \"Sun, 21 Oct 2012 17:11:58 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:11:58 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"26.5 KB\"}"
+      string: "{\"revision\": 430, \"rev\": \"1ae0b59ac45\", \"thumb_exists\": true, \"bytes\": 27143, \"modified\": \"Tue, 06 Nov 2012 21:07:35 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:07:35 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"26.5 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:11:58 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:35 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo.jpg
@@ -2147,7 +2147,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2156,7 +2156,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:00 GMT
+      - Tue, 06 Nov 2012 21:07:36 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2175,9 +2175,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/m1b9xnv6wv6g00f/Public/photo.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:11:59 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/dktyq4xy4czb71s/Public/photo.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:07:36 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:00 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:36 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo.jpg
@@ -2190,7 +2190,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2199,7 +2199,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:01 GMT
+      - Tue, 06 Nov 2012 21:07:37 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2218,9 +2218,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/m1b9xnv6wv6g00f/Public/photo.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:12:01 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/dktyq4xy4czb71s/Public/photo.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:07:37 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:01 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:37 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo_medium.jpg
@@ -2233,7 +2233,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2242,7 +2242,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:02 GMT
+      - Tue, 06 Nov 2012 21:07:38 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2261,9 +2261,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/1oq5rwmdvli38s1/Public/photo_medium.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:12:02 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/bfv25j41ykm166h/Public/photo_medium.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:07:38 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:03 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:38 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fphoto.jpg
@@ -2276,7 +2276,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2285,7 +2285,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:04 GMT
+      - Tue, 06 Nov 2012 21:07:39 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2295,7 +2295,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=MzQ1MTAyMTYwNzI5Njg2ODQ3Mjk5MjA3OTIxNzkwNTA2NTQ3MQ%3D%3D; expires=Fri, 20-Oct-2017 17:12:04 GMT; Path=/; httponly
+      - gvc=MTc0MDY3MTA1NDcwMjkzOTYzMDc2NzM3NDUxMTIyMjk1OTcwMzc0; expires=Sun, 05-Nov-2017 21:07:39 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -2306,9 +2306,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 636, \"rev\": \"27c01908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:12:04 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 431, \"rev\": \"1af0b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:07:38 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:04 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:39 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fphoto_medium.jpg
@@ -2321,7 +2321,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2330,7 +2330,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:06 GMT
+      - Tue, 06 Nov 2012 21:07:40 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2340,7 +2340,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=MjQ0MTY4MDgwNDQ5MjQ2NzQyNTk0NTUzOTAxNDA2MzExODIwMjYy; expires=Fri, 20-Oct-2017 17:12:06 GMT; Path=/; httponly
+      - gvc=MjE2Nzc4MzEyMzIyOTczOTAyNDM2NTIzMTE5OTA0NjQ2NzI5MTU3; expires=Sun, 05-Nov-2017 21:07:40 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -2351,7 +2351,7 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 637, \"rev\": \"27d01908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:12:05 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 432, \"rev\": \"1b00b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:07:39 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:06 GMT
-recorded_with: VCR 2.2.5
+  recorded_at: Tue, 06 Nov 2012 21:07:40 GMT
+recorded_with: VCR 2.3.0

--- a/spec/vcr_cassettes/Paperclip_Storage_Dropbox/arguments_for_has_attached_file/dropbox_options/path/has_the_original_filename_default.yml
+++ b/spec/vcr_cassettes/Paperclip_Storage_Dropbox/arguments_for_has_attached_file/dropbox_options/path/has_the_original_filename_default.yml
@@ -12,7 +12,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -21,7 +21,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:13 GMT
+      - Tue, 06 Nov 2012 21:07:41 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -34,7 +34,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:13 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:41 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/photo.jpg?overwrite=false
@@ -1421,7 +1421,7 @@ http_interactions:
       content-length: 
       - 61570
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1430,7 +1430,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:15 GMT
+      - Tue, 06 Nov 2012 21:07:42 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1447,9 +1447,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 638, \"rev\": \"27e01908bdc\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Sun, 21 Oct 2012 17:12:14 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:12:14 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
+      string: "{\"revision\": 433, \"rev\": \"1b10b59ac45\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Tue, 06 Nov 2012 21:07:41 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:07:41 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:15 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:42 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo_medium.jpg
@@ -1462,7 +1462,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -1471,7 +1471,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:16 GMT
+      - Tue, 06 Nov 2012 21:07:42 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -1484,7 +1484,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo_medium.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:16 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:42 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/photo_medium.jpg?overwrite=false
@@ -2106,7 +2106,7 @@ http_interactions:
       content-length: 
       - 27143
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2115,7 +2115,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:18 GMT
+      - Tue, 06 Nov 2012 21:07:43 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2132,9 +2132,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 639, \"rev\": \"27f01908bdc\", \"thumb_exists\": true, \"bytes\": 27143, \"modified\": \"Sun, 21 Oct 2012 17:12:18 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:12:18 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"26.5 KB\"}"
+      string: "{\"revision\": 434, \"rev\": \"1b20b59ac45\", \"thumb_exists\": true, \"bytes\": 27143, \"modified\": \"Tue, 06 Nov 2012 21:07:43 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:07:43 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"26.5 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:18 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:43 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo.jpg
@@ -2147,7 +2147,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2156,7 +2156,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:19 GMT
+      - Tue, 06 Nov 2012 21:07:44 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2175,9 +2175,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/m1b9xnv6wv6g00f/Public/photo.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:12:19 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/dktyq4xy4czb71s/Public/photo.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:07:44 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:19 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:44 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo.jpg
@@ -2190,7 +2190,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2199,7 +2199,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:21 GMT
+      - Tue, 06 Nov 2012 21:07:45 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2218,9 +2218,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/m1b9xnv6wv6g00f/Public/photo.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:12:21 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/dktyq4xy4czb71s/Public/photo.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:07:45 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:21 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:45 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo_medium.jpg
@@ -2233,7 +2233,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2242,7 +2242,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:22 GMT
+      - Tue, 06 Nov 2012 21:07:45 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2261,9 +2261,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/1oq5rwmdvli38s1/Public/photo_medium.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:12:22 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/bfv25j41ykm166h/Public/photo_medium.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:07:45 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:23 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:46 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fphoto.jpg
@@ -2276,7 +2276,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2285,7 +2285,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:24 GMT
+      - Tue, 06 Nov 2012 21:07:46 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2295,7 +2295,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=MzMxODMzNTU0OTYzMTI5MzEzNzY5NDUxMDM0NzA2NjYzMzY0ODQ%3D; expires=Fri, 20-Oct-2017 17:12:24 GMT; Path=/; httponly
+      - gvc=MzE2MTQwMzQzMzkwOTk4NDY2NDIxOTY3NTA0MjEzOTc5MjExOTA5; expires=Sun, 05-Nov-2017 21:07:46 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -2306,9 +2306,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 640, \"rev\": \"28001908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:12:24 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 435, \"rev\": \"1b30b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:07:46 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:24 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:46 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fphoto_medium.jpg
@@ -2321,7 +2321,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2330,7 +2330,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:26 GMT
+      - Tue, 06 Nov 2012 21:07:47 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2340,7 +2340,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=MTU0MTYxNTc3NjE1NDUxNDk4NDk4NTI1MjExOTA5ODIzOTM3MTI5; expires=Fri, 20-Oct-2017 17:12:26 GMT; Path=/; httponly
+      - gvc=MjI0NjY4MTg5MDU0MDk2MTQ5MjgwODI3OTMyNTkxODI3NzIzNzQz; expires=Sun, 05-Nov-2017 21:07:47 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -2351,7 +2351,7 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 641, \"rev\": \"28101908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:12:25 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 436, \"rev\": \"1b40b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:07:47 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:26 GMT
-recorded_with: VCR 2.2.5
+  recorded_at: Tue, 06 Nov 2012 21:07:48 GMT
+recorded_with: VCR 2.3.0

--- a/spec/vcr_cassettes/Paperclip_Storage_Dropbox/arguments_for_has_attached_file/dropbox_options/path/puts_the_instance_in_the_scope_passes_the_style_and_appends_the_extension_and_style.yml
+++ b/spec/vcr_cassettes/Paperclip_Storage_Dropbox/arguments_for_has_attached_file/dropbox_options/path/puts_the_instance_in_the_scope_passes_the_style_and_appends_the_extension_and_style.yml
@@ -12,7 +12,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -21,7 +21,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:11:34 GMT
+      - Tue, 06 Nov 2012 21:07:24 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -34,7 +34,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/original/User.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:11:34 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:24 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/original/User.jpg?overwrite=false
@@ -1421,7 +1421,7 @@ http_interactions:
       content-length: 
       - 61570
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1430,7 +1430,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:11:36 GMT
+      - Tue, 06 Nov 2012 21:07:25 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1447,9 +1447,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 628, \"rev\": \"27401908bdc\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Sun, 21 Oct 2012 17:11:36 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:11:36 +0000\", \"path\": \"/Public/original/User.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
+      string: "{\"revision\": 425, \"rev\": \"1a90b59ac45\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Tue, 06 Nov 2012 21:07:25 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:07:25 +0000\", \"path\": \"/Public/original/User.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:11:37 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:25 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/medium/User_medium.jpg
@@ -1462,7 +1462,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -1471,7 +1471,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:11:38 GMT
+      - Tue, 06 Nov 2012 21:07:26 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -1484,7 +1484,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/medium/User_medium.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:11:38 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:26 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/medium/User_medium.jpg?overwrite=false
@@ -2106,7 +2106,7 @@ http_interactions:
       content-length: 
       - 27143
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2115,7 +2115,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:11:40 GMT
+      - Tue, 06 Nov 2012 21:07:27 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2132,9 +2132,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 630, \"rev\": \"27601908bdc\", \"thumb_exists\": true, \"bytes\": 27143, \"modified\": \"Sun, 21 Oct 2012 17:11:40 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:11:40 +0000\", \"path\": \"/Public/medium/User_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"26.5 KB\"}"
+      string: "{\"revision\": 426, \"rev\": \"1aa0b59ac45\", \"thumb_exists\": true, \"bytes\": 27143, \"modified\": \"Tue, 06 Nov 2012 21:07:26 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:07:26 +0000\", \"path\": \"/Public/medium/User_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"26.5 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:11:40 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:27 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/original/User.jpg
@@ -2147,7 +2147,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2156,7 +2156,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:11:41 GMT
+      - Tue, 06 Nov 2012 21:07:28 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2175,9 +2175,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/7p3wrrvmqn6q24j/Public/original/User.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:11:41 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/neshzpy89tf1do5/Public/original/User.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:07:28 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:11:41 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:28 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/medium/User_medium.jpg
@@ -2190,7 +2190,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2199,7 +2199,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:11:43 GMT
+      - Tue, 06 Nov 2012 21:07:29 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2218,9 +2218,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/we5zsfe1ey5cc45/Public/medium/User_medium.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:11:43 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/qdt0sek1qdbx18c/Public/medium/User_medium.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:07:29 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:11:43 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:29 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/original/User.jpg
@@ -2233,7 +2233,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2242,7 +2242,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:11:45 GMT
+      - Tue, 06 Nov 2012 21:07:30 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2261,9 +2261,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/7p3wrrvmqn6q24j/Public/original/User.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:11:45 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/neshzpy89tf1do5/Public/original/User.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:07:30 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:11:45 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:30 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/medium/User_medium.jpg
@@ -2276,7 +2276,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2285,7 +2285,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:11:46 GMT
+      - Tue, 06 Nov 2012 21:07:30 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2304,9 +2304,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/we5zsfe1ey5cc45/Public/medium/User_medium.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:11:46 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/qdt0sek1qdbx18c/Public/medium/User_medium.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:07:30 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:11:46 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:30 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Foriginal%2FUser.jpg
@@ -2319,7 +2319,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2328,7 +2328,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:11:48 GMT
+      - Tue, 06 Nov 2012 21:07:31 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2338,7 +2338,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=MzYxMTc2MzE2NzE5NTU0NjQyOTAwMjUwODExMjYxNDc0NTg3ODA%3D; expires=Fri, 20-Oct-2017 17:11:48 GMT; Path=/; httponly
+      - gvc=MjkwMzQyMDIzMDk1ODY3NzQwNzg5MzUyOTgwNDY4ODE1MTgzNDI%3D; expires=Sun, 05-Nov-2017 21:07:31 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -2349,9 +2349,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 632, \"rev\": \"27801908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:11:48 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/original/User.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 427, \"rev\": \"1ab0b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:07:31 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/original/User.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:11:49 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:31 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fmedium%2FUser_medium.jpg
@@ -2364,7 +2364,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2373,7 +2373,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:11:50 GMT
+      - Tue, 06 Nov 2012 21:07:32 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2383,7 +2383,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=Mjk1OTE0MjkzNzMzODk0NDE2NTk5NDgxMDk3Mzc1ODgzNzc5MDU3; expires=Fri, 20-Oct-2017 17:11:50 GMT; Path=/; httponly
+      - gvc=NzQ3MDE5MjYwODc1NzMwOTA2ODEyOTAwMzQyMzgwMDUwOTc3MDY%3D; expires=Sun, 05-Nov-2017 21:07:32 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -2394,7 +2394,7 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 633, \"rev\": \"27901908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:11:50 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/medium/User_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 428, \"rev\": \"1ac0b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:07:32 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/medium/User_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:11:50 GMT
-recorded_with: VCR 2.2.5
+  recorded_at: Tue, 06 Nov 2012 21:07:32 GMT
+recorded_with: VCR 2.3.0

--- a/spec/vcr_cassettes/Paperclip_Storage_Dropbox/arguments_for_has_attached_file/dropbox_options/unique_filename/makes_the_file_path_unique.yml
+++ b/spec/vcr_cassettes/Paperclip_Storage_Dropbox/arguments_for_has_attached_file/dropbox_options/unique_filename/makes_the_file_path_unique.yml
@@ -12,7 +12,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -21,7 +21,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:27 GMT
+      - Tue, 06 Nov 2012 21:07:48 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -34,7 +34,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/user_4_avatar.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:27 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:48 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/user_4_avatar.jpg?overwrite=false
@@ -1421,7 +1421,7 @@ http_interactions:
       content-length: 
       - 61570
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1430,7 +1430,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:30 GMT
+      - Tue, 06 Nov 2012 21:07:49 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1447,9 +1447,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 642, \"rev\": \"28201908bdc\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Sun, 21 Oct 2012 17:12:29 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:12:29 +0000\", \"path\": \"/Public/user_4_avatar.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
+      string: "{\"revision\": 437, \"rev\": \"1b50b59ac45\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Tue, 06 Nov 2012 21:07:49 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:07:49 +0000\", \"path\": \"/Public/user_4_avatar.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:30 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:49 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/user_4_avatar_medium.jpg
@@ -1462,7 +1462,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -1471,7 +1471,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:31 GMT
+      - Tue, 06 Nov 2012 21:07:50 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -1484,7 +1484,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/user_4_avatar_medium.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:31 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:50 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/user_4_avatar_medium.jpg?overwrite=false
@@ -2106,7 +2106,7 @@ http_interactions:
       content-length: 
       - 27143
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -2115,7 +2115,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:33 GMT
+      - Tue, 06 Nov 2012 21:07:50 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -2132,9 +2132,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 643, \"rev\": \"28301908bdc\", \"thumb_exists\": true, \"bytes\": 27143, \"modified\": \"Sun, 21 Oct 2012 17:12:33 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:12:33 +0000\", \"path\": \"/Public/user_4_avatar_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"26.5 KB\"}"
+      string: "{\"revision\": 438, \"rev\": \"1b60b59ac45\", \"thumb_exists\": true, \"bytes\": 27143, \"modified\": \"Tue, 06 Nov 2012 21:07:50 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:07:50 +0000\", \"path\": \"/Public/user_4_avatar_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"26.5 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:33 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:50 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/user_5_avatar.jpg
@@ -2147,7 +2147,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -2156,7 +2156,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:35 GMT
+      - Tue, 06 Nov 2012 21:07:51 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -2169,7 +2169,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/user_5_avatar.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:36 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:51 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/user_5_avatar.jpg?overwrite=false
@@ -3556,7 +3556,7 @@ http_interactions:
       content-length: 
       - 61570
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -3565,7 +3565,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:42 GMT
+      - Tue, 06 Nov 2012 21:07:52 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -3582,9 +3582,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 644, \"rev\": \"28401908bdc\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Sun, 21 Oct 2012 17:12:38 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:12:38 +0000\", \"path\": \"/Public/user_5_avatar.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
+      string: "{\"revision\": 439, \"rev\": \"1b70b59ac45\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Tue, 06 Nov 2012 21:07:52 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:07:52 +0000\", \"path\": \"/Public/user_5_avatar.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:38 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:52 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/user_5_avatar_medium.jpg
@@ -3597,7 +3597,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -3606,7 +3606,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:39 GMT
+      - Tue, 06 Nov 2012 21:07:53 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -3619,7 +3619,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/user_5_avatar_medium.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:40 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:53 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/user_5_avatar_medium.jpg?overwrite=false
@@ -4241,7 +4241,7 @@ http_interactions:
       content-length: 
       - 27143
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -4250,7 +4250,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:41 GMT
+      - Tue, 06 Nov 2012 21:07:53 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -4267,9 +4267,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 645, \"rev\": \"28501908bdc\", \"thumb_exists\": true, \"bytes\": 27143, \"modified\": \"Sun, 21 Oct 2012 17:12:41 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:12:41 +0000\", \"path\": \"/Public/user_5_avatar_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"26.5 KB\"}"
+      string: "{\"revision\": 440, \"rev\": \"1b80b59ac45\", \"thumb_exists\": true, \"bytes\": 27143, \"modified\": \"Tue, 06 Nov 2012 21:07:53 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:07:53 +0000\", \"path\": \"/Public/user_5_avatar_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"26.5 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:41 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:53 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/user_4_avatar.jpg
@@ -4282,7 +4282,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -4291,7 +4291,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:43 GMT
+      - Tue, 06 Nov 2012 21:07:54 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -4310,9 +4310,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/han7lts0xaqad81/Public/user_4_avatar.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:12:43 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/vbxaox8u62m08ty/Public/user_4_avatar.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:07:54 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:43 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:54 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/user_4_avatar_medium.jpg
@@ -4325,7 +4325,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -4334,7 +4334,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:44 GMT
+      - Tue, 06 Nov 2012 21:07:55 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -4353,9 +4353,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/p3vi6pw7scj16bb/Public/user_4_avatar_medium.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:12:44 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/tgiguwaokk00h1x/Public/user_4_avatar_medium.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:07:55 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:44 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:55 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fuser_4_avatar.jpg
@@ -4368,7 +4368,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -4377,7 +4377,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:46 GMT
+      - Tue, 06 Nov 2012 21:07:55 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -4387,7 +4387,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=MTk1ODMyODU1ODcyODcyMTkwODc4MDgxOTUyNzQ3ODc2ODA2MzIy; expires=Fri, 20-Oct-2017 17:12:46 GMT; Path=/; httponly
+      - gvc=MTg0NjcwMzc4ODA4ODM4MzE1MjI2NDIwMzA2NzA1NDM2MzEzNTg4; expires=Sun, 05-Nov-2017 21:07:55 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -4398,9 +4398,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 646, \"rev\": \"28601908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:12:45 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/user_4_avatar.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 441, \"rev\": \"1b90b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:07:55 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/user_4_avatar.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:46 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:56 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fuser_4_avatar_medium.jpg
@@ -4413,7 +4413,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -4422,7 +4422,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:47 GMT
+      - Tue, 06 Nov 2012 21:07:56 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -4432,7 +4432,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=MjEzMTIyNTQ2Njg0MTE2NDg0MDgwMDY5MDQwOTk5MDI1OTgzNjky; expires=Fri, 20-Oct-2017 17:12:47 GMT; Path=/; httponly
+      - gvc=NDc3NzQzMTk4ODQ1MjEwNjMxMTIzMDY1NjYxODAyMDI0NjI2NzA%3D; expires=Sun, 05-Nov-2017 21:07:56 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -4443,9 +4443,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 647, \"rev\": \"28701908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:12:47 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/user_4_avatar_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 442, \"rev\": \"1ba0b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:07:56 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/user_4_avatar_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:47 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:57 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/user_5_avatar.jpg
@@ -4458,7 +4458,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -4467,7 +4467,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:49 GMT
+      - Tue, 06 Nov 2012 21:07:57 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -4486,9 +4486,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/sjeyu2nshszq0e4/Public/user_5_avatar.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:12:49 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/cecvbqrrrsfso26/Public/user_5_avatar.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:07:57 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:49 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:57 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/user_5_avatar_medium.jpg
@@ -4501,7 +4501,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -4510,7 +4510,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:51 GMT
+      - Tue, 06 Nov 2012 21:07:58 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -4529,9 +4529,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/ups0t3xzoinj13o/Public/user_5_avatar_medium.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:12:51 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/w0ztzhxcqpmuun9/Public/user_5_avatar_medium.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:07:58 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:51 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:58 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fuser_5_avatar.jpg
@@ -4544,7 +4544,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -4553,7 +4553,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:53 GMT
+      - Tue, 06 Nov 2012 21:07:59 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -4563,7 +4563,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=MzIxMDAzMjI5NDQzMTcyODExMzU5MjYyOTEyNjkwMDMxMTE0MTM0; expires=Fri, 20-Oct-2017 17:12:53 GMT; Path=/; httponly
+      - gvc=MzMyMzAyNjA0MDM1NzY0Njk3ODk0NzQzMDk5ODYzNjQxNzMzMzA2; expires=Sun, 05-Nov-2017 21:07:59 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -4574,9 +4574,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 648, \"rev\": \"28801908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:12:53 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/user_5_avatar.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 443, \"rev\": \"1bb0b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:07:59 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/user_5_avatar.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:53 GMT
+  recorded_at: Tue, 06 Nov 2012 21:07:59 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fuser_5_avatar_medium.jpg
@@ -4589,7 +4589,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -4598,7 +4598,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:12:55 GMT
+      - Tue, 06 Nov 2012 21:08:00 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -4608,7 +4608,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=MTM4MzQ5ODg0MjM2MDQ2MDc5MDU1MTAyMDY0MjU5NDM5NDgwMzE5; expires=Fri, 20-Oct-2017 17:12:55 GMT; Path=/; httponly
+      - gvc=Mjc3NDIwMjgxODM5NzY5MTMyNjM3MzE0ODMzMjc2MjkwNDE3Nzc5; expires=Sun, 05-Nov-2017 21:08:00 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -4619,7 +4619,7 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 649, \"rev\": \"28901908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:12:54 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/user_5_avatar_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 444, \"rev\": \"1bc0b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:07:59 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/user_5_avatar_medium.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:12:55 GMT
-recorded_with: VCR 2.2.5
+  recorded_at: Tue, 06 Nov 2012 21:08:00 GMT
+recorded_with: VCR 2.3.0

--- a/spec/vcr_cassettes/Paperclip_Storage_Dropbox/setter/handles_files_with_spaces_in_their_filename.yml
+++ b/spec/vcr_cassettes/Paperclip_Storage_Dropbox/setter/handles_files_with_spaces_in_their_filename.yml
@@ -12,7 +12,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -21,7 +21,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:13:30 GMT
+      - Tue, 06 Nov 2012 21:08:01 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -34,7 +34,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo_with_spaces.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:13:30 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:01 GMT
 - request: 
     method: put
     uri: https://api-content.dropbox.com/1/files_put/dropbox/Public/photo_with_spaces.jpg?overwrite=false
@@ -1421,7 +1421,7 @@ http_interactions:
       content-length: 
       - 61570
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1430,7 +1430,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:13:32 GMT
+      - Tue, 06 Nov 2012 21:08:01 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1447,9 +1447,9 @@ http_interactions:
       - no-cache
     body: 
       encoding: US-ASCII
-      string: "{\"revision\": 652, \"rev\": \"28c01908bdc\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Sun, 21 Oct 2012 17:13:32 +0000\", \"client_mtime\": \"Sun, 21 Oct 2012 17:13:32 +0000\", \"path\": \"/Public/photo_with_spaces.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
+      string: "{\"revision\": 445, \"rev\": \"1bd0b59ac45\", \"thumb_exists\": true, \"bytes\": 61570, \"modified\": \"Tue, 06 Nov 2012 21:08:01 +0000\", \"client_mtime\": \"Tue, 06 Nov 2012 21:08:01 +0000\", \"path\": \"/Public/photo_with_spaces.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"60.1 KB\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:13:32 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:01 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo_with_spaces.jpg
@@ -1462,7 +1462,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1471,7 +1471,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:13:34 GMT
+      - Tue, 06 Nov 2012 21:08:02 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1490,9 +1490,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/ibpzmxrjl6xpc9x/Public/photo_with_spaces.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:13:34 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/ddigbfsfovo122w/Public/photo_with_spaces.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:08:02 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:13:34 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:02 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo_with_spaces.jpg
@@ -1505,7 +1505,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1514,7 +1514,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:13:35 GMT
+      - Tue, 06 Nov 2012 21:08:03 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1533,9 +1533,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"url\": \"https://dl.dropbox.com/0/view/ibpzmxrjl6xpc9x/Public/photo_with_spaces.jpg\", \"expires\": \"Sun, 21 Oct 2012 21:13:35 +0000\"}"
+      string: "{\"url\": \"https://dl.dropbox.com/0/view/ddigbfsfovo122w/Public/photo_with_spaces.jpg\", \"expires\": \"Wed, 07 Nov 2012 01:08:03 +0000\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:13:35 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:03 GMT
 - request: 
     method: post
     uri: https://api.dropbox.com/1/fileops/delete?root=dropbox&path=%2FPublic%2Fphoto_with_spaces.jpg
@@ -1548,7 +1548,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 200
@@ -1557,7 +1557,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:13:37 GMT
+      - Tue, 06 Nov 2012 21:08:04 GMT
       content-type: 
       - text/javascript
       transfer-encoding: 
@@ -1567,7 +1567,7 @@ http_interactions:
       access-control-expose-headers: 
       - X-Dropbox-Metadata
       set-cookie: 
-      - gvc=MzIzMzc5NjcyNjQ5Mjc4NDEzMTQ1Mjc2Nzk1NzA4Mjg1ODQ3ODAx; expires=Fri, 20-Oct-2017 17:13:37 GMT; Path=/; httponly
+      - gvc=MTEzNzIzNTg5MzA0MDM0Njc0MDUzODQzODAyMDMwNDc3NDI0NDMw; expires=Sun, 05-Nov-2017 21:08:04 GMT; Path=/; httponly
       pragma: 
       - no-cache
       cache-control: 
@@ -1578,9 +1578,9 @@ http_interactions:
       - "*"
     body: 
       encoding: US-ASCII
-      string: "{\"is_deleted\": true, \"revision\": 653, \"rev\": \"28d01908bdc\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Sun, 21 Oct 2012 17:13:36 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo_with_spaces.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
+      string: "{\"is_deleted\": true, \"revision\": 446, \"rev\": \"1be0b59ac45\", \"thumb_exists\": true, \"bytes\": 0, \"modified\": \"Tue, 06 Nov 2012 21:08:04 +0000\", \"client_mtime\": \"Wed, 31 Dec 1969 23:59:59 +0000\", \"path\": \"/Public/photo_with_spaces.jpg\", \"is_dir\": false, \"icon\": \"page_white_picture\", \"root\": \"dropbox\", \"mime_type\": \"image/jpeg\", \"size\": \"0 bytes\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:13:37 GMT
+  recorded_at: Tue, 06 Nov 2012 21:08:04 GMT
 - request: 
     method: get
     uri: https://api.dropbox.com/1/media/dropbox/Public/photo_with_spaces.jpg
@@ -1593,7 +1593,7 @@ http_interactions:
       user-agent: 
       - OfficialDropboxRubySDK/1.5.1
       authorization: 
-      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="op7z8yczcf6hqbg", oauth_token="pfapjkwepp4gtig", oauth_signature="t9xl9p9xduqk4cp&cg0oln27dm66miv"
+      - OAuth oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="<APP_KEY>", oauth_token="<ACCESS_TOKEN>", oauth_signature="<APP_SECRET>&<ACCESS_TOKEN_SECRET>"
   response: 
     status: 
       code: 404
@@ -1602,7 +1602,7 @@ http_interactions:
       server: 
       - nginx/1.2.3
       date: 
-      - Sun, 21 Oct 2012 17:13:38 GMT
+      - Tue, 06 Nov 2012 21:08:05 GMT
       content-type: 
       - application/json
       transfer-encoding: 
@@ -1615,5 +1615,5 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"error\": \"Path '/Public/photo_with_spaces.jpg' not found\"}"
     http_version: "1.1"
-  recorded_at: Sun, 21 Oct 2012 17:13:38 GMT
-recorded_with: VCR 2.2.5
+  recorded_at: Tue, 06 Nov 2012 21:08:05 GMT
+recorded_with: VCR 2.3.0


### PR DESCRIPTION
Rebased this from my "remove secrets" branch. This changeset:
- removes the `config.yml` indirection while still using an example file
- makes the test suite give a developer-friendly error message if the config file does not exist
- prevents the after-hooks from spitting out extra errors if authentication fails
- re-records the VCR cassettes with all sensitive data scrubbed
- makes the `rake dropbox:authorize` task available in development

An issue not addressed here: Since the contents of the Dropbox are not reset before each test, you could end up in a state where VCR is giving you different responses than the live server would, potentially causing tests to pass when they should fail. My workaround would be to run the full suite VCR-less (with all cassettes cleared out) before committing something.
