### PR TITLE
Fix breakage with file extensions not 3 or 4 chars

### DIFF
--- a/lib/paperclip/storage/dropbox.rb
+++ b/lib/paperclip/storage/dropbox.rb
@@ -57,10 +57,14 @@ module Paperclip
       end
 
       def path_for_url(style)
-        result = instance.instance_exec(style, &file_path)
-        result += extension if result !~ /\.\w{3,4}$/
+        path = instance.instance_exec(style, &file_path)
         style_suffix = (style != default_style ? "_#{style}" : "")
-        result.sub(extension, "#{style_suffix}#{extension}")
+
+        if original_extension && path =~ /#{original_extension}$/
+          path.sub(original_extension, "#{style_suffix}#{original_extension}")
+        else
+          path + style_suffix + original_extension.to_s
+        end
       end
 
       def copy_to_local_file(style, destination_path)
@@ -71,8 +75,8 @@ module Paperclip
 
       private
 
-      def extension
-        original_filename[/\.\w{3,4}$/]
+      def original_extension
+        original_filename[/\.[^.]+$/]
       end
 
       def user_id

--- a/spec/files/test_file
+++ b/spec/files/test_file
@@ -1,0 +1,1 @@
+This is a test file.

--- a/spec/files/test_file.c
+++ b/spec/files/test_file.c
@@ -1,0 +1,1 @@
+// This is a test file.

--- a/spec/files/test_file.markdown
+++ b/spec/files/test_file.markdown
@@ -1,0 +1,1 @@
+## This is a test file.


### PR DESCRIPTION
I ran into an issue where attempting to attach a file with an extension that wasn't 3 or 4 characters long would fail with a "can't convert nil into String" error. I fixed this and added some test coverage to the relevant method.
