### PR TITLE
Default url with interpolation

### DIFF
--- a/lib/paperclip/storage/dropbox.rb
+++ b/lib/paperclip/storage/dropbox.rb
@@ -46,8 +46,8 @@ module Paperclip
 
       def url(*args)
         style = args.first.is_a?(Symbol) ? args.first : default_style
+        options = args.last.is_a?(Hash) ? args.last : {}
         if present?
-          options = args.last.is_a?(Hash) ? args.last : {}
           query = options[:download] ? "?dl=1" : ""
 
           if app_folder_mode
@@ -56,7 +56,7 @@ module Paperclip
             File.join("http://dl.dropbox.com/u/#{user_id}", path_for_url(style) + query)
           end
         else
-          @options[:interpolator].interpolate(@options[:default_url],nil,style)
+          @url_generator.for(style,options)
         end
       end
 

--- a/spec/paperclip/storage/dropbox_spec.rb
+++ b/spec/paperclip/storage/dropbox_spec.rb
@@ -205,6 +205,30 @@ describe Paperclip::Storage::Dropbox, :vcr do
         end
       end
     end
+    context "interpolated default url if it has no attachment  " do
+      def set_access_type(access_type)
+        stub_const("User", Class.new(ActiveRecord::Base) do
+          has_attached_file :avatar,
+            storage: :dropbox,
+            dropbox_credentials: CREDENTIALS_FILE[access_type],
+            styles: { medium: "300x300" },
+            default_url: ":style/missing.gif"
+        end)
+      end
+
+      it "returns url based on style if style not mentioned" do
+        set_access_type(:dropbox)
+        @user = User.create()
+        @user.avatar.url.should == "original/missing.gif"
+      end
+
+      it "returns url based on style mentioned" do
+        set_access_type(:dropbox)
+        @user = User.create()
+        @user.avatar.url(:medium).should == "medium/missing.gif"
+      end
+      
+    end
   end
 
   describe "#path" do


### PR DESCRIPTION
Default url returned when there is no attachment, was using the defaut_url mentioned in the options, but was not supporting interpolation. As Paperclip supports interpolation for all urls including default_url, I have added support for interpolation in default url in this gem which wasn't working earlier.
